### PR TITLE
Use Gradle placeholders in AndroidManifest for app auth redirect.

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Create secrets.properties
         env:
           DATA: ${{secrets.SECRETS_PROPERTIES}}
-        run: echo $DATA > /home/runner/work/Canoe/Canoe/secrets.properties
+        run: echo $DATA > secrets.properties
       - name: Download dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: ./gradlew androidDependencies
@@ -70,11 +70,11 @@ jobs:
       - name: Create google-services.json
         env:
           DATA: ${{secrets.GOOGLE_SERVICES_JSON}}
-        run: echo $DATA > /home/runner/work/Canoe/Canoe/canoe/src/google-services.json
+        run: echo $DATA > canoe/google-services.json
       - name: Create secrets.properties
         env:
           DATA: ${{secrets.SECRETS_PROPERTIES}}
-        run: echo $DATA > /home/runner/work/Canoe/Canoe/secrets.properties
+        run: echo $DATA > secrets.properties
       - name: Download dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: ./gradlew androidDependencies
@@ -112,11 +112,11 @@ jobs:
       - name: Create google-services.json
         env:
           DATA: ${{secrets.GOOGLE_SERVICES_JSON}}
-        run: echo $DATA > /home/runner/work/Canoe/Canoe/canoe/src/google-services.json
+        run: echo $DATA > canoe/google-services.json
       - name: Create secrets.properties
         env:
           DATA: ${{secrets.SECRETS_PROPERTIES}}
-        run: echo $DATA > /home/runner/work/Canoe/Canoe/secrets.properties
+        run: echo $DATA > secrets.properties
       - name: Download dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: ./gradlew androidDependencies

--- a/canoe/build.gradle.kts
+++ b/canoe/build.gradle.kts
@@ -24,8 +24,8 @@ android {
         }
 
         val oauthRedirectParts = extra["OAUTH_REDIRECT_URL"].toString().split("://")
-        manifestPlaceholders["appAuthRedirectScheme"] = oauthRedirectParts[0]
-        manifestPlaceholders["appAuthRedirectHost"] = oauthRedirectParts[1]
+        manifestPlaceholders["appOAuthRedirectScheme"] = oauthRedirectParts[0]
+        manifestPlaceholders["appOAuthRedirectHost"] = oauthRedirectParts[1].dropLastWhile { char -> char == '/' }
     }
 
     buildTypes {

--- a/canoe/build.gradle.kts
+++ b/canoe/build.gradle.kts
@@ -23,9 +23,9 @@ android {
             useSupportLibrary = true
         }
 
-        val oauthRedirectParts = extra["OAUTH_REDIRECT_URL"].toString().split("://")
-        manifestPlaceholders["appOAuthRedirectScheme"] = oauthRedirectParts[0]
-        manifestPlaceholders["appOAuthRedirectHost"] = oauthRedirectParts[1].dropLastWhile { char -> char == '/' }
+        val (scheme, host) = extra["OAUTH_REDIRECT_URL"].toString().split("://")
+        manifestPlaceholders["appOAuthRedirectScheme"] = scheme
+        manifestPlaceholders["appOAuthRedirectHost"] = host.dropLastWhile { char -> char == '/' }
     }
 
     buildTypes {

--- a/canoe/build.gradle.kts
+++ b/canoe/build.gradle.kts
@@ -22,6 +22,10 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+
+        val oauthRedirectParts = extra["OAUTH_REDIRECT_URL"].toString().split("://")
+        manifestPlaceholders["appAuthRedirectScheme"] = oauthRedirectParts[0]
+        manifestPlaceholders["appAuthRedirectHost"] = oauthRedirectParts[1]
     }
 
     buildTypes {

--- a/canoe/src/main/AndroidManifest.xml
+++ b/canoe/src/main/AndroidManifest.xml
@@ -31,8 +31,8 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:host="oauth"
-                    android:scheme="canoe" />
+                    android:host="${appAuthRedirectHost}"
+                    android:scheme="${appAuthRedirectScheme}" />
             </intent-filter>
         </activity>
 

--- a/canoe/src/main/AndroidManifest.xml
+++ b/canoe/src/main/AndroidManifest.xml
@@ -31,8 +31,8 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:host="${appAuthRedirectHost}"
-                    android:scheme="${appAuthRedirectScheme}" />
+                    android:host="${appOAuthRedirectHost}"
+                    android:scheme="${appOAuthRedirectScheme}" />
             </intent-filter>
         </activity>
 


### PR DESCRIPTION
It's not working when I run the app using my Wakatime's client_id and client_secret, because I forgot to change the redirect config in AndroidManifest.xml. Using placeholders for config might be a better choice.